### PR TITLE
Re-organised documentation of the sprint board

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ The development team has a large, physical whiteboard in their workspace called 
 
 It has two main sections:
 
-* Sprint Progress Columns (the Kanban columns which occupy most of the sprint board)
+* Sprint Progress Columns (which occupy most of the sprint board)
 * Distractions (used to track the amount of time the team spends on work unrelated to the sprint)
 
 ### Trello

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Tasks remain in the verify column until the code has been reviewed by another te
 
 Occasionally, stories may be deemed too small to be broken down into fine-grained tasks. These get grouped into a ‘Single Card Stories’ lane at the top of the board.
 
-To minimise the quantity of partially complete stories at the end of a sprint, a limit is imposed on the number of 'work in progress stories' (the number of stories currently being worked on). Currently, this limit is set at 3 stories.
+To minimise the quantity of partially complete stories at the end of a sprint, a [limit](https://github.com/cognisant/Docs.DevelopmentProcess/blob/master/docs/work-in-progress-limit.md) is imposed on the number of 'work in progress stories' (the number of stories currently being worked on). Currently, this limit is set at 3 stories.
 
 The sprint board is also used to track distractions which occur during a sprint.  A distraction is anything that prevented a team member from spending time on planned sprint tasks, e.g. time spent in meetings or responding to support tickets. These are recorded on Post-it notes with a description and a rough estimate of time spent on them. The development team reviews distractions during the [retrospective](#Retrospective) to identify trends in impediments, and account for lower than expected achievement during a sprint.
 

--- a/README.md
+++ b/README.md
@@ -263,12 +263,16 @@ Temporary channels for ad-hoc discussions are prefixed with `temp`, for example,
 Some channels are used with third-party integrations to provide notifications. These are prefixed with `bot`, for example, `#bot-monitoring`.
 
 ### Sprint Board
-The development team has a large, physical whiteboard in their workspace called the sprint board, it is used to track different aspect of the sprint.
 
-It has two main sections:
+The board is from Clarus (https://www.clarus.com/gb/products/).
 
-* Sprint Progress Columns (which occupy most of the sprint board)
-* Distractions (used to track the amount of time the team spends on work unrelated to the sprint)
+We use magnetic column headers (these are nearly the same as ours - https://www.patboard.com/shop/scrum-magnets-columncards/).
+
+Marking tape is used to separate the board's columns (https://agilestationery.co.uk/products/whiteboard-marking-tape-3mm-black).
+
+We use 'super sticky' Post-its for tasks and stories and distractions:
+76 x 76 mm - (https://www.amazon.co.uk/Post-Notes-Super-Sticky-Value/dp/B00RCJWSE8/ref=sr_1_3?keywords=post-its&qid=1558108247&s=officeproduct&sr=1-3)
+76 x 127 mm - (https://www.amazon.co.uk/Post-Notes-Energetic-Colours-extra/dp/B005IXGAWQ/ref=pd_sbs_229_2/260-3483606-7838723?_encoding=UTF8&pd_rd_i=B005IXGAWQ&pd_rd_r=5038ae10-78bb-11e9-9c2f-8dcc4d430633&pd_rd_w=H54wT&pd_rd_wg=IA7l7&pf_rd_p=18edf98b-139a-41ee-bb40-d725dd59d1d3&pf_rd_r=P88G6KFM95SS15ZFZ6CD&psc=1&refRID=P88G6KFM95SS15ZFZ6CD)
 
 ### Trello
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ During a sprint, the team’s progress on the tasks generated during the sprint 
 
 ![The Cognisant development team sprint board (captured mid-sprint)](/images/sprint-board.jpeg "The sprint board (captured mid-sprint)")
 
-Kanban columns (columns named ‘to do’, ‘doing’, ‘verify’, and ‘done’) occupy most of the sprint board. The team uses these to track the progress of work during a sprint.
+Columns named ‘to do’, ‘doing’, ‘verify’, and ‘done’ occupy most of the sprint board. The team uses these to track the progress of work during a sprint.
 
 Tasks belonging to stories are represented by Post-its on the board. Each story's task Post-its are grouped into horizontal lanes signified by a title card on the far left.
 The Post-its are moved through the columns on the board as they are worked on during the sprint. By the end of a sprint, most (if not all) of the task Post-its will have migrated from the ‘To do’ column through the ‘Doing’ and ‘Verify’ columns to the ‘Done’ column.

--- a/README.md
+++ b/README.md
@@ -270,8 +270,8 @@ We use magnetic column headers (these are nearly the same as ours - https://www.
 
 Marking tape is used to separate the board's columns (https://agilestationery.co.uk/products/whiteboard-marking-tape-3mm-black).
 
-We use 'super sticky' Post-its for tasks and stories and distractions:
-76 x 76 mm - (https://www.amazon.co.uk/Post-Notes-Super-Sticky-Value/dp/B00RCJWSE8/ref=sr_1_3?keywords=post-its&qid=1558108247&s=officeproduct&sr=1-3)
+We use 'super sticky' Post-its for tasks, stories and distractions:  
+76 x 76 mm - (https://www.amazon.co.uk/Post-Notes-Super-Sticky-Value/dp/B00RCJWSE8/ref=sr_1_3?keywords=post-its&qid=1558108247&s=officeproduct&sr=1-3)  
 76 x 127 mm - (https://www.amazon.co.uk/Post-Notes-Energetic-Colours-extra/dp/B005IXGAWQ/ref=pd_sbs_229_2/260-3483606-7838723?_encoding=UTF8&pd_rd_i=B005IXGAWQ&pd_rd_r=5038ae10-78bb-11e9-9c2f-8dcc4d430633&pd_rd_w=H54wT&pd_rd_wg=IA7l7&pf_rd_p=18edf98b-139a-41ee-bb40-d725dd59d1d3&pf_rd_r=P88G6KFM95SS15ZFZ6CD&psc=1&refRID=P88G6KFM95SS15ZFZ6CD)
 
 ### Trello

--- a/README.md
+++ b/README.md
@@ -219,13 +219,6 @@ Any possible process improvements agreed upon by the team get trialled in a futu
 
 An example of a process improvement derived from a retrospective meeting is [the work in progress limit](https://github.com/cognisant/Docs.DevelopmentProcess/blob/dev-with-retrospective/docs/work-in-progress-limit.md).
 
-##### Retrospective Goals 
-
-At the start of every sprint, the team agrees on a few tasks relating to retrospective discussion points to complete during the sprint.
-
-These tasks could be researching a possible process improvement, or documenting a newly adopted process improvement.
-The tasks are represented on the **sprint board** with a Post-it per task. There is a lane (row) on the **sprint board** used to track the completion of the retrospective-related tasks.
-
 #### Learning
 
 Each sprint, two team members are selected to spend a portion of their time learning. This training should be focused on technologies/tools/techniques which could be of benefit to the team in future. Team members have access to the company Pluralsight subscription which provides an array of video training courses but are also free to use other resources.

--- a/README.md
+++ b/README.md
@@ -138,23 +138,28 @@ During this meeting the team engages in the following activities to prepare for 
 - Each new story is discussed and broken down into a set of fine-grained technical tasks. These tasks are transcribed onto Post-it notes and attached to the sprint board to allow us to track work during the sprint.
   - Occasionally during this breakdown, the team discovers some complexity in implementing the feature which had not previously been considered. If this happens, the team may choose to re-estimate the story and, if necessary, change the set of stories selected for the sprint.
 
-#### Tracking Progress
+#### Tracking Progress - The Sprint Board
 
-During the sprint, the team’s progress on the tasks generated during the sprint kick-off is tracked using Post-it notes on a [large physical whiteboard](#sprint-board). This gives the entire team visibility of sprint progress at all times.
+The development team has a large, physical whiteboard in their workspace called the _sprint board_.
+
+During a sprint, the team’s progress on the tasks generated during the sprint kick-off is tracked using Post-it notes on the sprint board. This gives the entire team visibility of sprint progress at all times.
 
 ![The Cognisant development team sprint board (captured mid-sprint)](/images/sprint-board.jpeg "The sprint board (captured mid-sprint)")
 
-The board is arranged into columns named ‘to do’, ‘doing’, ‘verify’, and ‘done’. Tasks belonging to each story in the sprint are grouped into horizontal lanes signified by a title card on the far left.
+Kanban columns (columns named ‘to do’, ‘doing’, ‘verify’, and ‘done’) occupy most of the sprint board. The team uses these to track the progress of work during a sprint.
 
-Occasionally, stories may be deemed too small to be broken down into fine-grained tasks. These get grouped into a ‘Single Card Stories’ lane at the top of the board.
+Tasks belonging to stories are represented by Post-its on the board. Each story's task Post-its are grouped into horizontal lanes signified by a title card on the far left.
+The Post-its are moved through the columns on the board as they are worked on during the sprint. By the end of a sprint, most (if not all) of the task Post-its will have migrated from the ‘To do’ column through the ‘Doing’ and ‘Verify’ columns to the ‘Done’ column.
 
-When starting work, a team member takes a single task Post-it, adds their initials, and places it in the ‘doing’ column. When the work is complete, the task gets moved to the ‘verify’ column, and the team member begins the next task.
+When starting a task, a team member takes the single task Post-it, adds their initials, and places it in the ‘doing’ column. When the work is complete, the task gets moved to the ‘verify’ column, and the team member begins the next task.
 
 Tasks remain in the verify column until the code has been reviewed by another team member. Once tasks have been reviewed, they can be moved to the ‘done’ column. Sometimes it is possible to review a single task, but in practice, an entire story may be reviewed as a whole. If changes are requested as part of the review, these should be recorded onto new Post-its and placed in the ‘to do’ column.
 
-To minimise the quantity of partially complete stories at the end of a sprint, a limit is imposed on the number of work in progress stories. Currently, this limit is set at 3 stories.
+Occasionally, stories may be deemed too small to be broken down into fine-grained tasks. These get grouped into a ‘Single Card Stories’ lane at the top of the board.
 
-The sprint board is also used to track distractions which occur during a sprint. These are recorded on Post-it notes with a description and a rough estimate of time spent on them. A distraction is anything that prevented a team member from spending time on planned sprint tasks, e.g. time spent in meetings or responding to support tickets. These can be used to identify trends in impediments, and account for lower than expected achievement during a sprint.
+To minimise the quantity of partially complete stories at the end of a sprint, a limit is imposed on the number of 'work in progress stories' (the number of stories currently being worked on). Currently, this limit is set at 3 stories.
+
+The sprint board is also used to track distractions which occur during a sprint.  A distraction is anything that prevented a team member from spending time on planned sprint tasks, e.g. time spent in meetings or responding to support tickets. These are recorded on Post-it notes with a description and a rough estimate of time spent on them. The development team reviews distractions during the [retrospective](#Retrospective) to identify trends in impediments, and account for lower than expected achievement during a sprint.
 
 #### Daily Scrums
 
@@ -214,6 +219,13 @@ Any possible process improvements agreed upon by the team get trialled in a futu
 
 An example of a process improvement derived from a retrospective meeting is [the work in progress limit](https://github.com/cognisant/Docs.DevelopmentProcess/blob/dev-with-retrospective/docs/work-in-progress-limit.md).
 
+##### Retrospective Goals 
+
+At the start of every sprint, the team agrees on a few tasks relating to retrospective discussion points to complete during the sprint.
+
+These tasks could be researching a possible process improvement, or documenting a newly adopted process improvement.
+The tasks are represented on the **sprint board** with a Post-it per task. There is a lane (row) on the **sprint board** used to track the completion of the retrospective-related tasks.
+
 #### Learning
 
 Each sprint, two team members are selected to spend a portion of their time learning. This training should be focused on technologies/tools/techniques which could be of benefit to the team in future. Team members have access to the company Pluralsight subscription which provides an array of video training courses but are also free to use other resources.
@@ -251,22 +263,12 @@ Temporary channels for ad-hoc discussions are prefixed with `temp`, for example,
 Some channels are used with third-party integrations to provide notifications. These are prefixed with `bot`, for example, `#bot-monitoring`.
 
 ### Sprint Board
+The development team has a large, physical whiteboard in their workspace called the sprint board, it is used to track different aspect of the sprint.
 
-The development team has a large, physical whiteboard in their workspace called the _sprint board_. The sprint board has three main sections, each used to track a different aspect of the sprint.
+It has two main sections:
 
-#### Sprint Progress Columns
-
-Kanban columns occupy most of the sprint board. The team uses these to track the progress of work during a sprint. See [Tracking Progress](#Tracking-Progress) for more details.
-
-Each task is represented by a Post-it on the board. These Post-its move through the columns on the board throughout the sprint. By the end of a sprint, most (if not all) of the task Post-its will have migrated from the ‘To do’ column through the ‘Doing’ and ‘Verify’ columns to the ‘Done’ column.
-
-#### Distractions
-
-There is a reserved area on the sprint board for distractions. Development team members add a Post-it to this area whenever they deviate from sprint-related work. Team members add the duration of the distraction and their initials to the Post-it. The development team reviews distractions during the [retrospective](#Retrospective).
-
-#### Retrospective Goals
-
-There is an area on the sprint board for highlighting the current retrospective goals. These act as constant reminders to the team about what the agreed goals are for improving the process.
+* Sprint Progress Columns (the Kanban columns which occupy most of the sprint board)
+* Distractions (used to track the amount of time the team spends on work unrelated to the sprint)
 
 ### Trello
 


### PR DESCRIPTION
Re-organised content about the sprint board to reduce repetition and appropriately group the information.